### PR TITLE
Allow user to configure CRA_HOST.

### DIFF
--- a/cra_helper/__init__.py
+++ b/cra_helper/__init__.py
@@ -7,14 +7,20 @@ from cra_helper.asset_manifest import generate_manifest
 
 # Variables to help the template determine if it should try loading assets from the CRA live server
 _CRA_DEFAULT_PORT = 3000
+_CRA_DEFAULT_HOST = 'localhost'
 _port = _CRA_DEFAULT_PORT
+_host = _CRA_DEFAULT_HOST
 
 # Allow the user to specify the port create-react-app is running on
 if hasattr(settings, 'CRA_PORT') and type(settings.CRA_PORT) is int:
     _port = settings.CRA_PORT
+    
+# Allow the user to specify the host create-react-app is running on
+if hasattr(settings, 'CRA_HOST'):
+    _host = settings.CRA_HOST
 
 # The URL the create-react-app liveserver is accessible at
-CRA_URL = 'http://localhost:{}'.format(_port)
+CRA_URL = 'http://{}:{}'.format(_host, _port)
 
 if hasattr(settings, 'CRA_APP_NAME'):
     CRA_APP_NAME = settings.CRA_APP_NAME


### PR DESCRIPTION
When working within a container, it's necessary to specify a host as an IP, or loopback (e.g. 0.0.0.0).